### PR TITLE
Add upload capability

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,15 @@ random_gif
 ++++++++++
 An alias of ``giphypop.Giphy.screensaver``
 
+upload
+++++++
+Uploads a video or gif to giphy. Once the upload has completed, requests the
+full gif details and returns a GiphyImage (2 request calls).
+
+- **tags**: A list of tags to use on the uploaded gif, list
+- **file_path**: The path to the file to upload, string
+- **username**: The username of the account to upload to when using your own API key, string
+
 ------------------------------------------------------------------------------
 
 .. note::

--- a/README.rst
+++ b/README.rst
@@ -199,6 +199,33 @@ For example:
     'http://giphy.com/foo/bar/downsampled'
 
 
+Uploading
+---------
+
+The Giphy API will accept uploads of gifs or videos. You are able to upload
+using the public API key, but you won't be able to assign them to your username
+or delete them. In order to upload to your account, set the `username` when you
+and the API key when you upload.
+
+For example:
+
+.. code-block:: python
+
+    >>> from giphypop import upload
+    >>> gif = upload(["foo", "bar"], "mycat.gif")
+    >>> gif
+    GiphyImage<26BRvG76mOYcvRxss> at http://giphy.com/gifs/bar-foo-26BRvG76mOYcvRxss
+
+Or using your own API key to upload to your own account:
+
+.. code-block:: python
+
+    >>> from giphypop import upload
+    >>> gif = upload(["foo", "bar"], "mycat.gif", username="gifsarefun", api_key="abcdef12345678")
+    >>> gif
+    GiphyImage<26BRvG76mOYcvRxss> at http://giphy.com/gifs/bar-foo-26BRvG76mOYcvRxss
+
+
 Changelog
 ---------
 

--- a/giphypop.py
+++ b/giphypop.py
@@ -515,25 +515,25 @@ def translate(term=None, phrase=None, api_key=GIPHY_PUBLIC_KEY, strict=False,
         term=term, phrase=phrase, rating=rating)
 
 
-def trending(limit=DEFAULT_SEARCH_LIMIT, api_key=GIPHY_PUBLIC_KEY, strict=False,
-             rating=None):
+def trending(limit=DEFAULT_SEARCH_LIMIT, api_key=GIPHY_PUBLIC_KEY,
+             strict=False, rating=None):
     """
     Shorthand for creating a Giphy api wrapper with the given api key
     and then calling the trending method. Note that this will return
     a generator
     """
     return Giphy(api_key=api_key, strict=strict).trending(
-            limit=limit, rating=rating)
+        limit=limit, rating=rating)
 
 
-def trending_list(limit=DEFAULT_SEARCH_LIMIT, api_key=GIPHY_PUBLIC_KEY, strict=False,
-             rating=None):
+def trending_list(limit=DEFAULT_SEARCH_LIMIT, api_key=GIPHY_PUBLIC_KEY,
+                  strict=False, rating=None):
     """
     Shorthand for creating a Giphy api wrapper with the given api key
     and then calling the trending_list method.
     """
     return Giphy(api_key=api_key, strict=strict).trending_list(
-            limit=limit, rating=rating)
+        limit=limit, rating=rating)
 
 
 def gif(gif_id, api_key=GIPHY_PUBLIC_KEY, strict=False):
@@ -551,8 +551,13 @@ def screensaver(tag=None, api_key=GIPHY_PUBLIC_KEY, strict=False):
     """
     return Giphy(api_key=api_key, strict=strict).screensaver(tag=tag)
 
-
-
-
 # Alias
 random_gif = screensaver
+
+
+def upload(tags, file_path, username=None, api_key=GIPHY_PUBLIC_KEY):
+    """
+    Shorthand for creating a Giphy api wrapper with the given api key
+    and then calling the upload method.
+    """
+    return Giphy(api_key=api_key).upload(tags, file_path, username)

--- a/giphypop.py
+++ b/giphypop.py
@@ -555,9 +555,11 @@ def screensaver(tag=None, api_key=GIPHY_PUBLIC_KEY, strict=False):
 random_gif = screensaver
 
 
-def upload(tags, file_path, username=None, api_key=GIPHY_PUBLIC_KEY):
+def upload(tags, file_path, username=None, api_key=GIPHY_PUBLIC_KEY,
+           strict=False):
     """
     Shorthand for creating a Giphy api wrapper with the given api key
     and then calling the upload method.
     """
-    return Giphy(api_key=api_key).upload(tags, file_path, username)
+    return Giphy(api_key=api_key, strict=strict).upload(
+        tags, file_path, username)

--- a/giphypop.py
+++ b/giphypop.py
@@ -12,6 +12,7 @@ from functools import partial
 
 
 GIPHY_API_ENDPOINT = 'http://api.giphy.com/v1/gifs'
+GIPHY_UPLOAD_ENDPOINT = 'http://upload.giphy.com/v1/gifs'
 
 # Note this is a public beta key and may be inactive at some point
 GIPHY_PUBLIC_KEY = 'dc6zaTOxFJmzC'
@@ -455,6 +456,34 @@ class Giphy(object):
     # Alias
     random_gif = screensaver
 
+    def upload(self, tags, file_path, username=None):
+        """
+        Uploads a gif from the filesystem to Giphy.
+
+        :param tags: Tags to apply to the uploaded image
+        :type tags: list
+        :param file_path: Path at which the image can be found
+        :type file_path: string
+        :param username: Your channel username if not using public API key
+        """
+        params = {
+            'api_key': self.api_key,
+            'tags': ','.join(tags)
+        }
+        if username is not None:
+            params['username'] = username
+
+        with open(file_path, 'rb') as f:
+            resp = requests.post(
+                GIPHY_UPLOAD_ENDPOINT, params=params, files={'file': f})
+
+        resp.raise_for_status()
+
+        data = resp.json()
+        self._check_or_raise(data.get('meta', {}))
+
+        return self.gif(data['data']['id'])
+
 
 def search(term=None, phrase=None, limit=DEFAULT_SEARCH_LIMIT,
            api_key=GIPHY_PUBLIC_KEY, strict=False, rating=None):
@@ -521,6 +550,8 @@ def screensaver(tag=None, api_key=GIPHY_PUBLIC_KEY, strict=False):
     and then calling the screensaver method.
     """
     return Giphy(api_key=api_key, strict=strict).screensaver(tag=tag)
+
+
 
 
 # Alias


### PR DESCRIPTION
Enable uploading gifs to Giphy.

```
In [1]: import giphypop

In [2]: g = giphypop.Giphy()
giphypop.py:240: UserWarning: You are using the giphy public api key. This should be used for testing only and may be deactivated in the future. See https://github.com/Giphy/GiphyAPI.
  warnings.warn('You are using the giphy public api key. This '

In [3]: gif = g.upload(["test"], "/home/flyte/Videos/gif/output.gif")
gif

In [4]: gif
Out[4]: GiphyImage<3o72F1yGknib10Gfis> at http://giphy.com/gifs/test-3o72F1yGknib10Gfis
```
