### PR TITLE
Get the error message from 'msg' key if 'error_message' doesn't exist.

### DIFF
--- a/giphypop.py
+++ b/giphypop.py
@@ -251,7 +251,7 @@ class Giphy(object):
 
     def _check_or_raise(self, meta):
         if meta.get('status') != 200:
-            raise GiphyApiException(meta.get('error_message'))
+            raise GiphyApiException(meta.get('error_message', meta.get('msg')))
 
     def _fetch(self, endpoint_name, **params):
         """


### PR DESCRIPTION
When you try to upload a file (such as a .webm) that Giphy doesn't support, you currently receive the following traceback:

```python
In [19]: cap = "capture-1488866937406.webm"

In [20]: up = giphy.upload(["test"], cap)
---------------------------------------------------------------------------
GiphyApiException                         Traceback (most recent call last)
<ipython-input-20-56a005758976> in <module>()
----> 1 up = giphy.upload(["test"], cap)

/home/flyte/.virtualenvs/giphypop/lib/python2.7/site-packages/giphypop.pyc in upload(self, tags, file_path, username)
    482 
    483         data = resp.json()
--> 484         self._check_or_raise(data.get('meta', {}))
    485 
    486         return self.gif(data['data']['id'])

/home/flyte/.virtualenvs/giphypop/lib/python2.7/site-packages/giphypop.pyc in _check_or_raise(self, meta)
    252     def _check_or_raise(self, meta):
    253         if meta.get('status') != 200:
--> 254             raise GiphyApiException(meta.get('error_message'))
    255 
    256     def _fetch(self, endpoint_name, **params):

GiphyApiException: None
```

This is because the response from Giphy looks like this:

```python
ipdb> resp
<Response [200]>
ipdb> resp.text
u'  \n\n{"meta":{"status":400,"msg":"Bad Request - Gif processing failed","response_id":"58c165d601faeb2ce42c62c5"}}'
```

I'm not sure whether Giphy ever sends back `error_message` as opposed to `msg` [as seen here](https://github.com/Giphy/GiphyAPI#upload-request-response-format) but this patch tries both. Perhaps `error_message` can be removed if it's no longer used.

After this patch it'll look something like this:

```python
In [4]: up = giphy.upload(["test"], cap)
---------------------------------------------------------------------------
GiphyApiException                         Traceback (most recent call last)
<ipython-input-4-56a005758976> in <module>()
----> 1 up = giphy.upload(["test"], cap)

/home/flyte/dev/giphypop/giphypop.py in upload(self, tags, file_path, username)
    482 
    483         data = resp.json()
--> 484         self._check_or_raise(data.get('meta', {}))
    485 
    486         return self.gif(data['data']['id'])

/home/flyte/dev/giphypop/giphypop.py in _check_or_raise(self, meta)
    252     def _check_or_raise(self, meta):
    253         if meta.get('status') != 200:
--> 254             raise GiphyApiException(meta.get('error_message', meta.get('msg')))
    255 
    256     def _fetch(self, endpoint_name, **params):

GiphyApiException: Bad Request - Gif processing failed
```