### PR TITLE
Removed Unneccessary stopIterationException 

### DIFF
--- a/giphypop.py
+++ b/giphypop.py
@@ -318,12 +318,16 @@ class Giphy(object):
                 yield GiphyImage(item)
 
                 if limit is not None and results_yielded >= limit:
-                    raise StopIteration
+                    break
+                #Exception is not required and requires unneccessary try except block
+                    # raise StopIteration
 
             # Check yieled limit and whether or not there are more items
             if (page >= data['pagination']['total_count'] or
                     (limit is not None and results_yielded >= limit)):
-                raise StopIteration
+                break
+                #Exception is not required and requires unneccessary try except block
+                # raise StopIteration
 
     def search_list(self, term=None, phrase=None, limit=DEFAULT_SEARCH_LIMIT,
                     rating=None):


### PR DESCRIPTION
StopIteration Exception is not required in search method and search list method as it adds burden of additional try except block 